### PR TITLE
feat: Update configuration and dependencies

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <uses-permission android:name="android.permission.CAPTURE_AUDIO_OUTPUT"/>
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+<!--    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>-->
     <queries>
         <!-- If your app opens https URLs -->
         <intent>

--- a/lib/data/datasources/remote/base_client.dart
+++ b/lib/data/datasources/remote/base_client.dart
@@ -30,7 +30,7 @@ class ClientCreator {
     dio2.options.sendTimeout = Duration(seconds: 60);    // Send timeout
 
     // Set base URL
-    dio2.options.baseUrl =kTestApiUrl;  // Replace with your base URL
+    dio2.options.baseUrl =kBASE_URL;  // Replace with your base URL
 
 
 

--- a/linux/flutter/ephemeral/.plugin_symlinks/connectivity_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/connectivity_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/connectivity_plus-6.1.4/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/connectivity_plus-6.1.4/

--- a/linux/flutter/ephemeral/.plugin_symlinks/device_info_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/device_info_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/device_info_plus-11.5.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/device_info_plus-11.5.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/file_picker
+++ b/linux/flutter/ephemeral/.plugin_symlinks/file_picker
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/file_picker-10.2.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/file_picker-10.2.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/file_saver
+++ b/linux/flutter/ephemeral/.plugin_symlinks/file_saver
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/file_saver-0.2.14/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/file_saver-0.2.14/

--- a/linux/flutter/ephemeral/.plugin_symlinks/file_selector_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/file_selector_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/file_selector_linux-0.9.3+2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/file_selector_linux-0.9.3+2/

--- a/linux/flutter/ephemeral/.plugin_symlinks/flutter_local_notifications_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/flutter_local_notifications_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_local_notifications_linux-6.0.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_local_notifications_linux-6.0.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_linux-1.2.3/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_linux-1.2.3/

--- a/linux/flutter/ephemeral/.plugin_symlinks/hikvision
+++ b/linux/flutter/ephemeral/.plugin_symlinks/hikvision
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/hikvision-0.0.2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/hikvision-0.0.2/

--- a/linux/flutter/ephemeral/.plugin_symlinks/image_picker_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/image_picker_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_linux-0.2.1+2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_linux-0.2.1+2/

--- a/linux/flutter/ephemeral/.plugin_symlinks/package_info_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/package_info_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/package_info_plus-8.3.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/package_info_plus-8.3.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/path_provider_linux-2.2.1/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/path_provider_linux-2.2.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/platform_device_id_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/platform_device_id_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/platform_device_id_linux-1.0.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/platform_device_id_linux-1.0.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/share_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/share_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/share_plus-11.0.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/share_plus-11.0.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/shared_preferences_linux-2.4.1/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/shared_preferences_linux-2.4.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/url_launcher_linux-3.2.1/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/url_launcher_linux-3.2.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/wakelock_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/wakelock_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/wakelock_plus-1.3.2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/wakelock_plus-1.3.2/

--- a/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
+++ b/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
@@ -1,10 +1,10 @@
 // This is a generated file; do not edit or check into version control.
-FLUTTER_ROOT=C:\src\flutter
-FLUTTER_APPLICATION_PATH=D:\work\chashift
+FLUTTER_ROOT=E:\flutter_versions\flutter_windows_3.29.0-stable\flutter
+FLUTTER_APPLICATION_PATH=E:\Working-Apps\chashift-projects\cashiftNew
 COCOAPODS_PARALLEL_CODE_SIGN=true
 FLUTTER_BUILD_DIR=build
-FLUTTER_BUILD_NAME=1.0.0
-FLUTTER_BUILD_NUMBER=1
+FLUTTER_BUILD_NAME=1.4.9
+FLUTTER_BUILD_NUMBER=116
 DART_OBFUSCATION=false
 TRACK_WIDGET_CREATION=true
 TREE_SHAKE_ICONS=false

--- a/macos/Flutter/ephemeral/flutter_export_environment.sh
+++ b/macos/Flutter/ephemeral/flutter_export_environment.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=C:\src\flutter"
-export "FLUTTER_APPLICATION_PATH=D:\work\chashift"
+export "FLUTTER_ROOT=E:\flutter_versions\flutter_windows_3.29.0-stable\flutter"
+export "FLUTTER_APPLICATION_PATH=E:\Working-Apps\chashift-projects\cashiftNew"
 export "COCOAPODS_PARALLEL_CODE_SIGN=true"
 export "FLUTTER_BUILD_DIR=build"
-export "FLUTTER_BUILD_NAME=1.0.0"
-export "FLUTTER_BUILD_NUMBER=1"
+export "FLUTTER_BUILD_NAME=1.4.9"
+export "FLUTTER_BUILD_NUMBER=116"
 export "DART_OBFUSCATION=false"
 export "TRACK_WIDGET_CREATION=true"
 export "TREE_SHAKE_ICONS=false"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.4.9+116
 
 environment:
   sdk: ^3.7.0

--- a/windows/flutter/ephemeral/.plugin_symlinks/connectivity_plus
+++ b/windows/flutter/ephemeral/.plugin_symlinks/connectivity_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/connectivity_plus-6.1.4/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/connectivity_plus-6.1.4/

--- a/windows/flutter/ephemeral/.plugin_symlinks/device_info_plus
+++ b/windows/flutter/ephemeral/.plugin_symlinks/device_info_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/device_info_plus-11.5.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/device_info_plus-11.5.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/file_picker
+++ b/windows/flutter/ephemeral/.plugin_symlinks/file_picker
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/file_picker-10.2.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/file_picker-10.2.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/file_saver
+++ b/windows/flutter/ephemeral/.plugin_symlinks/file_saver
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/file_saver-0.2.14/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/file_saver-0.2.14/

--- a/windows/flutter/ephemeral/.plugin_symlinks/file_selector_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/file_selector_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/file_selector_windows-0.9.3+4/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/file_selector_windows-0.9.3+4/

--- a/windows/flutter/ephemeral/.plugin_symlinks/firebase_core
+++ b/windows/flutter/ephemeral/.plugin_symlinks/firebase_core
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/firebase_core-3.14.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/firebase_core-3.14.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/flutter_inappwebview_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/flutter_inappwebview_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_inappwebview_windows-0.6.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_inappwebview_windows-0.6.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/flutter_local_notifications_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/flutter_local_notifications_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_local_notifications_windows-1.0.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_local_notifications_windows-1.0.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_windows-3.1.2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/flutter_secure_storage_windows-3.1.2/

--- a/windows/flutter/ephemeral/.plugin_symlinks/geolocator_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/geolocator_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/geolocator_windows-0.2.5/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/geolocator_windows-0.2.5/

--- a/windows/flutter/ephemeral/.plugin_symlinks/hikvision
+++ b/windows/flutter/ephemeral/.plugin_symlinks/hikvision
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/hikvision-0.0.2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/hikvision-0.0.2/

--- a/windows/flutter/ephemeral/.plugin_symlinks/image_picker_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/image_picker_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_windows-0.2.1+1/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/image_picker_windows-0.2.1+1/

--- a/windows/flutter/ephemeral/.plugin_symlinks/local_auth_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/local_auth_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/local_auth_windows-1.0.11/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/local_auth_windows-1.0.11/

--- a/windows/flutter/ephemeral/.plugin_symlinks/package_info_plus
+++ b/windows/flutter/ephemeral/.plugin_symlinks/package_info_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/package_info_plus-8.3.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/package_info_plus-8.3.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/path_provider_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/path_provider_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/path_provider_windows-2.3.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/path_provider_windows-2.3.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/permission_handler_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/permission_handler_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/permission_handler_windows-0.2.1/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/permission_handler_windows-0.2.1/

--- a/windows/flutter/ephemeral/.plugin_symlinks/platform_device_id_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/platform_device_id_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/platform_device_id_windows-1.0.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/platform_device_id_windows-1.0.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/share_plus
+++ b/windows/flutter/ephemeral/.plugin_symlinks/share_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/share_plus-11.0.0/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/share_plus-11.0.0/

--- a/windows/flutter/ephemeral/.plugin_symlinks/shared_preferences_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/shared_preferences_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/shared_preferences_windows-2.4.1/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/shared_preferences_windows-2.4.1/

--- a/windows/flutter/ephemeral/.plugin_symlinks/url_launcher_windows
+++ b/windows/flutter/ephemeral/.plugin_symlinks/url_launcher_windows
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/url_launcher_windows-3.1.4/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/url_launcher_windows-3.1.4/

--- a/windows/flutter/ephemeral/.plugin_symlinks/wakelock_plus
+++ b/windows/flutter/ephemeral/.plugin_symlinks/wakelock_plus
@@ -1,1 +1,1 @@
-C:/Users/khattab/AppData/Local/Pub/Cache/hosted/pub.dev/wakelock_plus-1.3.2/
+C:/Users/harbe/AppData/Local/Pub/Cache/hosted/pub.dev/wakelock_plus-1.3.2/


### PR DESCRIPTION
- Bumps the application version to 1.4.9+116.
- Comments out the `READ_MEDIA_IMAGES` permission in `AndroidManifest.xml`.
- Sets the Dio client's base URL to the production `kBASE_URL`.